### PR TITLE
Fix:Carpeta_Apis

### DIFF
--- a/apis/autos_api.py
+++ b/apis/autos_api.py
@@ -16,10 +16,6 @@ router = APIRouter(
 
 
 def get_db():
-    """
-    Provee una sesión de base de datos activa.
-    Se usa como dependencia en los endpoints.
-    """
     db = SessionLocal()
     try:
         yield db
@@ -37,10 +33,6 @@ def comprar_auto(
     autonomia: int | None = None,
     db: Session = Depends(get_db),
 ):
-    """
-    Registra un nuevo auto en el concesionario.
-    Soporta autos nuevos, usados y eléctricos con sus atributos.
-    """
     concesionario = Concesionario(db)
     tipo_normalizado = tipo.lower()
 
@@ -73,20 +65,18 @@ def comprar_auto(
 
 @router.get("/", response_model=List[AutoOut])
 def listar_autos(db: Session = Depends(get_db)):
-    """
-    Lista todos los autos disponibles.
-    Solo muestra aquellos que no han sido vendidos.
-    """
     concesionario = Concesionario(db)
     return concesionario.mostrar_autos()
 
 
+@router.get("/vendidos", response_model=List[AutoOut])
+def listar_autos_vendidos(db: Session = Depends(get_db)):
+    concesionario = Concesionario(db)
+    return concesionario.mostrar_autos_vendidos()
+
+
 @router.get("/{auto_id}", response_model=AutoOut)
 def obtener_auto(auto_id: UUID, db: Session = Depends(get_db)):
-    """
-    Obtiene la información de un auto por su ID único.
-    Lanza un error 404 si no existe.
-    """
     auto = db.query(auto_crud.Auto).filter_by(id=auto_id).first()
     if not auto:
         raise HTTPException(status_code=404, detail="Auto no encontrado")
@@ -95,10 +85,6 @@ def obtener_auto(auto_id: UUID, db: Session = Depends(get_db)):
 
 @router.post("/vender/{auto_id}")
 def vender_auto(auto_id: UUID, db: Session = Depends(get_db)):
-    """
-    Marca un auto como vendido usando su ID.
-    Retorna la información básica del auto vendido.
-    """
     auto = auto_crud.marcar_vendido(db, auto_id)
     if not auto:
         raise HTTPException(status_code=404, detail="Auto no encontrado o ya vendido")
@@ -108,22 +94,8 @@ def vender_auto(auto_id: UUID, db: Session = Depends(get_db)):
     }
 
 
-@router.get("/vendidos", response_model=List[AutoOut])
-def listar_autos_vendidos(db: Session = Depends(get_db)):
-    """
-    Lista todos los autos ya vendidos.
-    Incluye su información completa.
-    """
-    concesionario = Concesionario(db)
-    return concesionario.mostrar_autos_vendidos()
-
-
 @router.put("/{auto_id}", response_model=AutoOut)
 def actualizar_auto(auto_id: UUID, auto: AutoCreate, db: Session = Depends(get_db)):
-    """
-    Actualiza los datos de un auto por su ID.
-    Si no existe, devuelve error 404.
-    """
     db_auto = auto_crud.actualizar_auto(db, auto_id, auto)
     if not db_auto:
         raise HTTPException(status_code=404, detail="Auto no encontrado")
@@ -132,10 +104,6 @@ def actualizar_auto(auto_id: UUID, auto: AutoCreate, db: Session = Depends(get_d
 
 @router.delete("/{auto_id}")
 def eliminar_auto(auto_id: UUID, db: Session = Depends(get_db)):
-    """
-    Elimina un auto del sistema usando su ID.
-    Devuelve confirmación si el auto existía.
-    """
     auto = auto_crud.eliminar_auto(db, auto_id)
     if not auto:
         raise HTTPException(status_code=404, detail="Auto no encontrado")

--- a/apis/empleados_api.py
+++ b/apis/empleados_api.py
@@ -29,42 +29,30 @@ def get_db():
 
 @router.post("/", response_model=EmpleadoOut, status_code=status.HTTP_201_CREATED)
 def crear_empleado(empleado: EmpleadoCreate, db: Session = Depends(get_db)):
-    """
-    Crea un nuevo empleado en el sistema.
-    Retorna los datos del empleado registrado.
-    """
     service = EmpleadoService(db)
     return service.registrar_empleado(empleado)
 
 
 @router.get("/", response_model=List[EmpleadoOut])
 def listar_empleados(db: Session = Depends(get_db)):
-    """
-    Lista todos los empleados registrados.
-    Retorna una lista de objetos empleados.
-    """
     service = EmpleadoService(db)
     return service.listar_empleados()
 
 
-@router.get("/{empleado_id}", response_model=EmpleadoOut)
-def obtener_empleado(empleado_id: UUID, db: Session = Depends(get_db)):
-    """
-    Obtiene la información de un empleado por su ID único.
-    Lanza error 404 si no existe.
-    """
-    empleado = db.query(empleado_crud.Empleado).filter_by(id=empleado_id).first()
-    if not empleado:
-        raise HTTPException(status_code=404, detail="Empleado no encontrado")
-    return empleado
+@router.get("/vendedores")
+def listar_vendedores(db: Session = Depends(get_db)):
+    service = EmpleadoService(db)
+    return service.listar_vendedores()
+
+
+@router.get("/tecnicos")
+def listar_tecnicos(db: Session = Depends(get_db)):
+    service = EmpleadoService(db)
+    return service.listar_tecnicos()
 
 
 @router.post("/vendedores")
 def registrar_vendedor(vendedor: VendedorCreate, db: Session = Depends(get_db)):
-    """
-    Marca un empleado como vendedor.
-    Requiere el ID del empleado existente.
-    """
     service = EmpleadoService(db)
     return service.registrar_vendedor(vendedor)
 
@@ -73,42 +61,22 @@ def registrar_vendedor(vendedor: VendedorCreate, db: Session = Depends(get_db)):
 def registrar_tecnico(
     tecnico: MantenimientoEmpleadoCreate, db: Session = Depends(get_db)
 ):
-    """
-    Registra a un empleado como técnico de mantenimiento.
-    Incluye el tipo de vehículos en los que se especializa.
-    """
     service = EmpleadoService(db)
     return service.registrar_tecnico(tecnico)
 
 
-@router.get("/vendedores")
-def listar_vendedores(db: Session = Depends(get_db)):
-    """
-    Obtiene todos los empleados registrados como vendedores.
-    Retorna la lista de vendedores actuales.
-    """
-    service = EmpleadoService(db)
-    return service.listar_vendedores()
-
-
-@router.get("/tecnicos")
-def listar_tecnicos(db: Session = Depends(get_db)):
-    """
-    Obtiene todos los empleados registrados como técnicos.
-    Retorna la lista de técnicos actuales.
-    """
-    service = EmpleadoService(db)
-    return service.listar_tecnicos()
+@router.get("/{empleado_id}", response_model=EmpleadoOut)
+def obtener_empleado(empleado_id: UUID, db: Session = Depends(get_db)):
+    empleado = db.query(empleado_crud.Empleado).filter_by(id=empleado_id).first()
+    if not empleado:
+        raise HTTPException(status_code=404, detail="Empleado no encontrado")
+    return empleado
 
 
 @router.put("/{empleado_id}", response_model=EmpleadoOut)
 def actualizar_empleado(
     empleado_id: UUID, empleado: EmpleadoCreate, db: Session = Depends(get_db)
 ):
-    """
-    Actualiza los datos de un empleado existente.
-    Retorna el empleado actualizado o error 404 si no existe.
-    """
     db_empleado = empleado_crud.actualizar_empleado(db, empleado_id, empleado)
     if not db_empleado:
         raise HTTPException(status_code=404, detail="Empleado no encontrado")
@@ -117,10 +85,6 @@ def actualizar_empleado(
 
 @router.delete("/{empleado_id}")
 def eliminar_empleado(empleado_id: UUID, db: Session = Depends(get_db)):
-    """
-    Elimina un empleado de la base de datos.
-    Retorna confirmación o error 404 si no existe.
-    """
     empleado = empleado_crud.eliminar_empleado(db, empleado_id)
     if not empleado:
         raise HTTPException(status_code=404, detail="Empleado no encontrado")


### PR DESCRIPTION
Refactor: Reordenamiento de Endpoints de API (Ruta)
He reordenado la secuencia de los endpoints dentro de la carpeta /apis para prevenir conflictos de enrutamiento (routing).

El orden anterior estaba causando que las rutas de recursos específicos, que usan UUIDs fueran interpretadas incorrectamente. El router estaba priorizando estas rutas sobre otras rutas que usan nombres fijos.